### PR TITLE
Fix memory allocation bug

### DIFF
--- a/busyhttp.py
+++ b/busyhttp.py
@@ -32,7 +32,7 @@ def busy_cpu_seconds(seconds):
 
 @application.route("/memory/<int:mb>")
 def busy_memory_mb(mb):
-    memBuf.buffer += ['A' * MEGABYTE] * mb
+    memBuf.buffer += ['A' * MEGABYTE for _ in range(mb)]
     time.sleep(1)
     return "I've allocated " + str(mb) + " MB of memory.\n"
 

--- a/tests/test_busyhttp.py
+++ b/tests/test_busyhttp.py
@@ -1,0 +1,20 @@
+import unittest
+from busyhttp import application, memBuf
+
+class BusyHttpMemoryTests(unittest.TestCase):
+    def setUp(self):
+        memBuf.buffer.clear()
+        self.client = application.test_client()
+
+    def test_memory_allocation_creates_unique_strings(self):
+        self.client.get('/memory/2')
+        self.assertEqual(len(memBuf.buffer), 2)
+        self.assertNotEqual(id(memBuf.buffer[0]), id(memBuf.buffer[1]))
+
+    def test_memory_free_releases_specified_amount(self):
+        self.client.get('/memory/3')
+        self.client.get('/memfree/2')
+        self.assertEqual(len(memBuf.buffer), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allocate unique strings for memory testing so multiple MBs are actually reserved
- add unit tests for memory allocation and release behavior

## Testing
- `python -m unittest tests.test_busyhttp -v`

------
https://chatgpt.com/codex/tasks/task_b_685969469128832f9f405f6e1394653d